### PR TITLE
enabled debug mode

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -15,6 +15,7 @@ parts =
 recipe = plone.recipe.zope2instance
 user = admin:admin
 relative-paths = true
+debug-mode = on
 eggs =
     Plone
     Pillow

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -16,6 +16,7 @@ recipe = plone.recipe.zope2instance
 user = admin:admin
 relative-paths = true
 debug-mode = on
+
 eggs =
     Plone
     Pillow


### PR DESCRIPTION
Switching off the diazo theme only works in debug mode.
This is needed to support training exercises where ?diazo.off=1 is appended to URLs
see the end of this document: https://github.com/plone/training/blob/master/theming/ttw-advanced_2.rst
