### PR TITLE
Fixed deployment errors due to conflicted versions

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -39,3 +39,5 @@ plone.app.blocks = 4.0.0rc1
 plone.app.drafts = 1.1.1
 plone.app.mosaic = 2.0.0rc1
 plone.resource = 1.2
+setuptools = 33.1.1
+zc.buildout = 2.9.3


### PR DESCRIPTION
Hey, since the deployment on Heroku has errors as described here https://github.com/collective/training-sandbox/issues/5 . I think this is the solution to this problem.