### PR TITLE
Update zc.buildout version

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -55,4 +55,4 @@ plone.app.mosaic = 2.0rc5
 plone.formwidget.multifile = 2.0
 plone.jsonserializer = 0.9.3
 setuptools = 33.1.1
-zc.buildout = 2.9.3
+zc.buildout = 2.9.4


### PR DESCRIPTION
Update version for zc.buzildout. Heroku was unable to build Plone because of version conflict.