### PR TITLE
changed the unified installer from 5.0.4 to 5.0.8

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -12,9 +12,9 @@ CACHE_DIR=$2  # -> use this dir for caching between compiles
 ENV_DIR=$3  # -> environment variables are stored as files inside here
 INSTALL_DIR="$BUILD_DIR/.heroku/vendor/buildout"  # -> after buildout is
 # finished, copy results to this dir so they get compressed into a Heroku slug
-UI_URL=https://launchpad.net/plone/5.0/5.0.4/+download/Plone-5.0.4-UnifiedInstaller.tgz
-UI_TARBALL=Plone-5.0.4-UnifiedInstaller.tgz
-UI_DIR=Plone-5.0.4-UnifiedInstaller
+UI_URL=https://launchpad.net/plone/5.0/5.0.8/+download/Plone-5.0.8-UnifiedInstaller.tgz
+UI_TARBALL=Plone-5.0.8-UnifiedInstaller.tgz
+UI_DIR=Plone-5.0.8-UnifiedInstaller
 
 
 # make sure dirs exist


### PR DESCRIPTION
The buildpack now installs 5.0.8, for an effective cache source it was necessary to use the 5.0.8 unified installer.